### PR TITLE
Add some convenient color helpers

### DIFF
--- a/color.go
+++ b/color.go
@@ -7,48 +7,48 @@ import "github.com/fatih/color"
 // we can't have an elegant "...color.Attribute" argument and have to use a slice
 
 func (u *UI) PrintColor(colors []color.Attribute, args ...interface{}) (int, error) {
-	colorString := color.New(colors...).SprintFunc()(args)
+	colorString := color.New(colors...).SprintFunc()(args...)
 	return u.Print(colorString)
 }
 
 func (u *UI) PrintfColor(colors []color.Attribute, format string, args ...interface{}) (int, error) {
-	colorString := color.New(colors...).SprintFunc()(args)
-	return u.Printf(format, colorString)
+	colorString := color.New(colors...).SprintfFunc()(format, args...)
+	return u.Print(colorString)
 }
 
 func (u *UI) PrintlnColor(colors []color.Attribute, args ...interface{}) (int, error) {
-	colorString := color.New(colors...).SprintFunc()(args)
-	return u.Println(colorString)
+	colorString := color.New(colors...).SprintlnFunc()(args...)
+	return u.Print(colorString)
 }
 
 // Helper functions for simple color printing
 
 func (u *UI) RedPrintln(args ...interface{}) (int, error) {
 	colors := []color.Attribute{color.FgRed}
-	return u.PrintlnColor(colors, args)
+	return u.PrintlnColor(colors, args...)
 }
 
 func (u *UI) RedBoldPrintln(args ...interface{}) (int, error) {
 	colors := []color.Attribute{color.FgRed, color.Bold}
-	return u.PrintlnColor(colors, args)
+	return u.PrintlnColor(colors, args...)
 }
 
 func (u *UI) YellowPrintln(args ...interface{}) (int, error) {
 	colors := []color.Attribute{color.FgYellow}
-	return u.PrintlnColor(colors, args)
+	return u.PrintlnColor(colors, args...)
 }
 
 func (u *UI) YellowBoldPrintln(args ...interface{}) (int, error) {
 	colors := []color.Attribute{color.FgYellow, color.Bold}
-	return u.PrintlnColor(colors, args)
+	return u.PrintlnColor(colors, args...)
 }
 
 func (u *UI) GreenPrintln(args ...interface{}) (int, error) {
 	colors := []color.Attribute{color.FgGreen}
-	return u.PrintlnColor(colors, args)
+	return u.PrintlnColor(colors, args...)
 }
 
 func (u *UI) GreenBoldPrintln(args ...interface{}) (int, error) {
 	colors := []color.Attribute{color.FgGreen, color.Bold}
-	return u.PrintlnColor(colors, args)
+	return u.PrintlnColor(colors, args...)
 }

--- a/color.go
+++ b/color.go
@@ -24,31 +24,25 @@ func (u *UI) PrintlnColor(colors []color.Attribute, args ...interface{}) (int, e
 // Helper functions for simple color printing
 
 func (u *UI) RedPrintln(args ...interface{}) (int, error) {
-	colors := []color.Attribute{color.FgRed}
-	return u.PrintlnColor(colors, args...)
+	return u.PrintlnColor([]color.Attribute{color.FgRed}, args...)
 }
 
 func (u *UI) RedBoldPrintln(args ...interface{}) (int, error) {
-	colors := []color.Attribute{color.FgRed, color.Bold}
-	return u.PrintlnColor(colors, args...)
+	return u.PrintlnColor([]color.Attribute{color.FgRed, color.Bold}, args...)
 }
 
 func (u *UI) YellowPrintln(args ...interface{}) (int, error) {
-	colors := []color.Attribute{color.FgYellow}
-	return u.PrintlnColor(colors, args...)
+	return u.PrintlnColor([]color.Attribute{color.FgYellow}, args...)
 }
 
 func (u *UI) YellowBoldPrintln(args ...interface{}) (int, error) {
-	colors := []color.Attribute{color.FgYellow, color.Bold}
-	return u.PrintlnColor(colors, args...)
+	return u.PrintlnColor([]color.Attribute{color.FgYellow, color.Bold}, args...)
 }
 
 func (u *UI) GreenPrintln(args ...interface{}) (int, error) {
-	colors := []color.Attribute{color.FgGreen}
-	return u.PrintlnColor(colors, args...)
+	return u.PrintlnColor([]color.Attribute{color.FgGreen}, args...)
 }
 
 func (u *UI) GreenBoldPrintln(args ...interface{}) (int, error) {
-	colors := []color.Attribute{color.FgGreen, color.Bold}
-	return u.PrintlnColor(colors, args...)
+	return u.PrintlnColor([]color.Attribute{color.FgGreen, color.Bold}, args...)
 }

--- a/color.go
+++ b/color.go
@@ -1,0 +1,54 @@
+package termui
+
+import "github.com/fatih/color"
+
+// These mirror their equivalent functions in ui.go
+// Unfortunately since Print is already variadic,
+// we can't have an elegant "...color.Attribute" argument and have to use a slice
+
+func (u *UI) PrintColor(colors []color.Attribute, args ...interface{}) (int, error) {
+	colorString := color.New(colors...).SprintFunc()(args)
+	return u.Print(colorString)
+}
+
+func (u *UI) PrintfColor(colors []color.Attribute, format string, args ...interface{}) (int, error) {
+	colorString := color.New(colors...).SprintFunc()(args)
+	return u.Printf(format, colorString)
+}
+
+func (u *UI) PrintlnColor(colors []color.Attribute, args ...interface{}) (int, error) {
+	colorString := color.New(colors...).SprintFunc()(args)
+	return u.Println(colorString)
+}
+
+// Helper functions for simple color printing
+
+func (u *UI) RedPrintln(args ...interface{}) (int, error) {
+	colors := []color.Attribute{color.FgRed}
+	return u.PrintlnColor(colors, args)
+}
+
+func (u *UI) RedBoldPrintln(args ...interface{}) (int, error) {
+	colors := []color.Attribute{color.FgRed, color.Bold}
+	return u.PrintlnColor(colors, args)
+}
+
+func (u *UI) YellowPrintln(args ...interface{}) (int, error) {
+	colors := []color.Attribute{color.FgYellow}
+	return u.PrintlnColor(colors, args)
+}
+
+func (u *UI) YellowBoldPrintln(args ...interface{}) (int, error) {
+	colors := []color.Attribute{color.FgYellow, color.Bold}
+	return u.PrintlnColor(colors, args)
+}
+
+func (u *UI) GreenPrintln(args ...interface{}) (int, error) {
+	colors := []color.Attribute{color.FgGreen}
+	return u.PrintlnColor(colors, args)
+}
+
+func (u *UI) GreenBoldPrintln(args ...interface{}) (int, error) {
+	colors := []color.Attribute{color.FgGreen, color.Bold}
+	return u.PrintlnColor(colors, args)
+}

--- a/color_test.go
+++ b/color_test.go
@@ -1,0 +1,58 @@
+package termui
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/fatih/color"
+)
+
+const boldMagentaCode = "\x1b[1;35m"
+const backToNormalCode = "\x1b[0m"
+
+func TestColor_PrintColor(t *testing.T) {
+	t.Parallel()
+
+	ui, state := setup()
+	one, three := "one", "three"
+	two := 5
+	colors := []color.Attribute{color.Bold, color.FgMagenta}
+
+	ui.PrintColor(colors, one, two, three)
+	expected := fmt.Sprint(one, two, three)
+	expected = boldMagentaCode + expected + backToNormalCode
+	if got := state.out.String(); got != expected {
+		t.Errorf("output was wrong: %q, expected: %q", got, expected)
+	}
+}
+
+func TestColor_PrintfColor(t *testing.T) {
+	t.Parallel()
+
+	ui, state := setup()
+	format, value := "test %s printf", "the"
+	colors := []color.Attribute{color.Bold, color.FgMagenta}
+
+	ui.PrintfColor(colors, format, value)
+	expected := fmt.Sprintf(format, value)
+	expected = boldMagentaCode + expected + backToNormalCode
+	if got := state.out.String(); got != expected {
+		t.Errorf("output was wrong: %q, expected: %q", got, expected)
+	}
+}
+
+func TestColor_PrintlnColor(t *testing.T) {
+	t.Parallel()
+
+	ui, state := setup()
+	one, three := "one", "three"
+	two := 5
+	colors := []color.Attribute{color.Bold, color.FgMagenta}
+
+	ui.PrintlnColor(colors, one, two, three)
+	expected := fmt.Sprintln(one, two, three)
+	expected = boldMagentaCode + expected + backToNormalCode
+	if got := state.out.String(); got != expected {
+		t.Errorf("output was wrong: %q, expected: %q", got, expected)
+	}
+}


### PR DESCRIPTION
For instance, in my current CLI, this would let me turn this:

``` go
redBoldColor := color.New(color.FgRed, color.Bold).SprintfFunc()
failureName := redBoldColor("%s: Failed with code %d", failedResult.TestFile, failedResult.ExitCode)
ui.Println(failureName)
failureString := fmt.Sprintf("Output:\n%s", failedResult.Output)
failureString = color.RedString(failureString)
ui.Println(failureString)
```

Into this:

``` go
ui.RedBoldPrintln("%s: Failed with code %d", failedResult.TestFile, failedResult.ExitCode)
ui.RedPrintln("Output:\n%s", failedResult.Output)
```

It also lets me remove a direct dependency to `github.com/fatih/color`
